### PR TITLE
Indent levelname by default

### DIFF
--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 DEFAULT_FORMAT = (
-    "%(asctime)s [%(process)d] %(color)s%(levelname)s "
+    "%(asctime)s [%(process)d] %(color)s%(levelname)-8.8s "
     "%(name)s: %(message)s%(color_stop)s"
 )
 

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -47,7 +47,7 @@ class TestDaiquiri(testtools.TestCase):
         ))
         warnings.warn("omg!")
         line = stream.getvalue()
-        self.assertIn("WARNING py.warnings: ", line)
+        self.assertIn("WARNING  py.warnings: ", line)
         self.assertIn("daiquiri/tests/test_daiquiri.py:48: "
                       "UserWarning: omg!\n  warnings.warn(\"omg!\")\n",
                       line)


### PR DESCRIPTION
This change indents levelname for a nicer output. Though
warning and critical get truncated at five chars.