### PR TITLE
Use better terminal default colors for logs

### DIFF
--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -26,10 +26,10 @@ DEFAULT_FORMAT = (
 class ColorFormatter(logging.Formatter):
     # TODO(jd) Allow configuration
     LEVEL_COLORS = {
-        logging.DEBUG: '\033[00;32m',  # GREEN
+        logging.DEBUG: '\033[00;37m',  # GRAY
         logging.INFO: '\033[00;36m',  # CYAN
-        logging.WARN: '\033[01;33m',  # BOLD YELLOW
-        logging.ERROR: '\033[01;31m',  # BOLD RED
+        logging.WARN: '\033[00;33m',  # YELLOW
+        logging.ERROR: '\033[00;31m',  # RED
         logging.CRITICAL: '\033[01;31m',  # BOLD RED
     }
 


### PR DESCRIPTION
I know "better" can be subjective, but I feel that green color for DEBUG messages is a strange choice. Also it would be better if ERROR and CRITICAL logs have a slightly different color, I think.

This patch changes DEBUG to a light gray color and ERROR to a normal red color.