### PR TITLE
Fix wrong constructor call

### DIFF
--- a/daiquiri/handlers.py
+++ b/daiquiri/handlers.py
@@ -62,7 +62,7 @@ class JournalHandler(logging.Handler):
     def __init__(self, program_name):
         if not journal:
             raise RuntimeError("Systemd bindings do not exist")
-        super(SyslogHandler, self).__init__()
+        super(JournalHandler, self).__init__()
         self.program_name = program_name
 
     def emit(self, record):


### PR DESCRIPTION
Fixes:

```python
Traceback (most recent call last):
  File "./main.py", line 11, in <module>
    import daiquiri
  File "/usr/lib/python3.6/site-packages/daiquiri/__init__.py", line 19, in <module>
    from daiquiri import output
  File "/usr/lib/python3.6/site-packages/daiquiri/output.py", line 232, in <module>
    preconfigured['journal'] = Journal()
  File "/usr/lib/python3.6/site-packages/daiquiri/output.py", line 180, in __init__
    super(Journal, self).__init__(handlers.JournalHandler(program_name),
  File "/usr/lib/python3.6/site-packages/daiquiri/handlers.py", line 65, in __init__
    super(SyslogHandler, self).__init__()
TypeError: super(type, obj): obj must be an instance or subtype of type
```