### PR TITLE
Adds ArbitraryContextAdapter.

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -58,49 +58,6 @@ class KeywordArgumentAdapter(logging.LoggerAdapter):
             self.logger.setLevel(level)
 
 
-PARAMETER_TEMPLATE = ' [{0}: {1}]'
-
-
-class ArbitraryContextAdapter(logging.LoggerAdapter):
-    """Logger adapter to add context string to log record's extra data
-
-    Keywords passed to the log call are formatted into a context
-    string, which is then added to the "extra" dictionary passed to
-    the underlying logger so they are emitted with the log message and
-    available to the format string.
-
-    Example:
-      A formatter with the format string of "%(context)s %(messages)"
-      called like logger.info("A message.", test1="a", test2="b")
-      would log the message: " [test1: a] [test2: b] A message."
-
-    Special keywords:
-
-    extra
-      An existing dictionary of extra values to be passed to the
-      logger. If present, the dictionary is copied and extended.
-    """
-
-    def process(self, msg, kwargs):
-        # Make a new extra dictionary combining the values we were
-        # given when we were constructed and a 'context' key which
-        # will contain a formatted string containing anything from
-        # kwargs.
-        extra = self.extra.copy()
-        if 'extra' in kwargs:
-            extra.update(kwargs.pop('extra'))
-        # Format any unknown keyword arguments into the context string.
-        context = ''
-        for name in list(kwargs.keys()):
-            if name == 'exc_info':
-                continue
-            context += PARAMETER_TEMPLATE.format(name, kwargs.pop(name))
-        extra['context'] = context
-        extra['_daiquiri_extra'] = extra
-        kwargs['extra'] = extra
-        return msg, kwargs
-
-
 _LOGGERS = weakref.WeakValueDictionary()
 
 

--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -61,20 +61,18 @@ class KeywordArgumentAdapter(logging.LoggerAdapter):
 _LOGGERS = weakref.WeakValueDictionary()
 
 
-def getLogger(name=None, adapter_class=KeywordArgumentAdapter, **kwargs):
+def getLogger(name=None, **kwargs):
     """Build a logger with the given name.
 
     :param name: The name for the logger. This is usually the module
                  name, ``__name__``.
     :type name: string
-    :param adapter_class: The class to instantiate the logger's adapter with.
-    :type adapter_class: type
     """
     adapter = _LOGGERS.get(name)
     if not adapter:
         # NOTE(jd) Keep using the `adapter' variable here because so it's not
         # collected by Python since _LOGGERS contains only a weakref
-        adapter = adapter_class(logging.getLogger(name), kwargs)
+        adapter = KeywordArgumentAdapter(logging.getLogger(name), kwargs)
         _LOGGERS[name] = adapter
     return adapter
 

--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -58,21 +58,66 @@ class KeywordArgumentAdapter(logging.LoggerAdapter):
             self.logger.setLevel(level)
 
 
+PARAMETER_TEMPLATE = ' [{0}: {1}]'
+
+
+class ArbitraryContextAdapter(logging.LoggerAdapter):
+    """Logger adapter to add context string to log record's extra data
+
+    Keywords passed to the log call are formatted into a context
+    string, which is then added to the "extra" dictionary passed to
+    the underlying logger so they are emitted with the log message and
+    available to the format string.
+
+    Example:
+      A formatter with the format string of "%(context)s %(messages)"
+      called like logger.info("A message.", test1="a", test2="b")
+      would log the message: " [test1: a] [test2: b] A message."
+
+    Special keywords:
+
+    extra
+      An existing dictionary of extra values to be passed to the
+      logger. If present, the dictionary is copied and extended.
+    """
+
+    def process(self, msg, kwargs):
+        # Make a new extra dictionary combining the values we were
+        # given when we were constructed and a 'context' key which
+        # will contain a formatted string containing anything from
+        # kwargs.
+        extra = self.extra.copy()
+        if 'extra' in kwargs:
+            extra.update(kwargs.pop('extra'))
+        # Format any unknown keyword arguments into the context string.
+        context = ''
+        for name in list(kwargs.keys()):
+            if name == 'exc_info':
+                continue
+            context += PARAMETER_TEMPLATE.format(name, kwargs.pop(name))
+        extra['context'] = context
+        extra['_daiquiri_extra'] = extra
+        kwargs['extra'] = extra
+        return msg, kwargs
+
+
 _LOGGERS = weakref.WeakValueDictionary()
 
 
-def getLogger(name=None, **kwargs):
+def getLogger(name=None, adapter_class=KeywordArgumentAdapter, **kwargs):
     """Build a logger with the given name.
 
     :param name: The name for the logger. This is usually the module
                  name, ``__name__``.
     :type name: string
+    :param adapter_class: The class to instantiate the logger's adapter with.
+    :type adapter_class: type
     """
     adapter = _LOGGERS.get(name)
     if not adapter:
         # NOTE(jd) Keep using the `adapter' variable here because so it's not
         # collected by Python since _LOGGERS contains only a weakref
-        adapter = KeywordArgumentAdapter(logging.getLogger(name), kwargs)
+        adapter = adapter_class(logging.getLogger(name), kwargs)
         _LOGGERS[name] = adapter
     return adapter
 

--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -50,6 +50,13 @@ class KeywordArgumentAdapter(logging.LoggerAdapter):
         kwargs['extra'] = extra
         return msg, kwargs
 
+    if sys.version_info.major == 2:
+        def setLevel(self, level):
+            """
+            Set the specified level on the underlying logger.
+            """
+            self.logger.setLevel(level)
+
 
 _LOGGERS = weakref.WeakValueDictionary()
 

--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -19,7 +19,7 @@ except ImportError:
 
 DEFAULT_FORMAT = (
     "%(asctime)s [%(process)d] %(color)s%(levelname)-8.8s "
-    "%(name)s: %(message)s%(color_stop)s"
+    "%(name)s %(extras)s: %(message)s%(color_stop)s"
 )
 
 
@@ -35,19 +35,74 @@ class ColorFormatter(logging.Formatter):
 
     COLOR_STOP = '\033[0m'
 
-    def format(self, record):
+    def add_color(self, record):
         if getattr(record, "_stream_is_a_tty", False):
             record.color = self.LEVEL_COLORS[record.levelno]
             record.color_stop = self.COLOR_STOP
         else:
             record.color = ""
             record.color_stop = ""
-        s = super(ColorFormatter, self).format(record)
+
+    def remove_color(self, record):
         del record.color
         del record.color_stop
+
+    def format(self, record):
+        self.add_color(record)
+        s = super(ColorFormatter, self).format(record)
+        self.remove_color(record)
         return s
 
 
-TEXT_FORMATTER = ColorFormatter(fmt=DEFAULT_FORMAT)
+class ExtrasFormatter(logging.Formatter):
+    def __init__(self,
+                 fmt=None,
+                 datefmt=None,
+                 style='%',
+                 keywords=None,
+                 extras_template='[{0}: {1}]',
+                 extras_separator=' '):
+        self.keywords = keywords
+        self.extras_separator = extras_separator
+        self.extras_template = extras_template
+        super(ExtrasFormatter, self).__init__(fmt=fmt,
+                                              datefmt=datefmt,
+                                              style=style)
+
+    def add_extras(self, record):
+        if self.keywords is None or not hasattr(record, '_daiquiri_extra'):
+            return
+
+        # Format any unknown keyword arguments into the extras string.
+        extras_string = ''
+        separator = ''
+        for k, v in record._daiquiri_extra.items():
+            if k != '_daiquiri_extra' and k not in self.keywords:
+                extras_string += separator + self.extras_template.format(k, v)
+                # Only set this after the first iteration to prevent a
+                # leading space
+                separator = self.extras_separator
+
+        record.extras = extras_string
+
+    def remove_extras(self, record):
+        del record.extras
+
+    def format(self, record):
+        self.add_extras(record)
+        s = super(ExtrasFormatter, self).format(record)
+        self.remove_extras(record)
+        return s
+
+
+class ColorExtrasFormatter(ExtrasFormatter, ColorFormatter):
+    def format(self, record):
+        self.add_color(record)
+        s = super(ColorExtrasFormatter, self).format(record)
+        self.remove_color(record)
+        return s
+
+
+TEXT_FORMATTER = ColorExtrasFormatter(fmt=DEFAULT_FORMAT)
 if jsonlogger:
     JSON_FORMATTER = jsonlogger.JsonFormatter()

--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -24,6 +24,8 @@ DEFAULT_FORMAT = (
 
 
 class ColorFormatter(logging.Formatter):
+    """Colorizes log output"""
+
     # TODO(jd) Allow configuration
     LEVEL_COLORS = {
         logging.DEBUG: '\033[00;32m',  # GREEN
@@ -55,6 +57,34 @@ class ColorFormatter(logging.Formatter):
 
 
 class ExtrasFormatter(logging.Formatter):
+    """Formats extra keywords into %(extras)s placeholder.
+
+    Any keywords passed to a logging call will be formatted into a
+    "extras" string and included in a logging message.
+    Example:
+        logger.info('my message', extra='keyword')
+    will cause an "extras" string of:
+        [extra: keyword]
+    to be inserted into the format in place of %(extras)s.
+
+    The optional `keywords` argument must be passed into the init
+    function to enable this functionality. Without it normal daiquri
+    formatting will be applied. Any keywords included in the
+    `keywords` parameter will not be included in the "extras" string.
+
+    Special keywords:
+
+    keywords
+      A list of strings containing keywords to filter out of the
+      "extras" string.
+
+    extras_template
+      A format string to use instead of '[{0}: {1}]'
+
+    extras_separator
+      What character to "join" multiple "extras" with.
+    """
+
     def __init__(self,
                  fmt=None,
                  datefmt=None,
@@ -63,8 +93,8 @@ class ExtrasFormatter(logging.Formatter):
                  extras_template='[{0}: {1}]',
                  extras_separator=' '):
         self.keywords = keywords
-        self.extras_separator = extras_separator
         self.extras_template = extras_template
+        self.extras_separator = extras_separator
         super(ExtrasFormatter, self).__init__(fmt=fmt,
                                               datefmt=datefmt,
                                               style=style)
@@ -97,6 +127,8 @@ class ExtrasFormatter(logging.Formatter):
 
 
 class ColorExtrasFormatter(ColorFormatter, ExtrasFormatter):
+    """Combines functionality of ColorFormatter and ExtrasFormatter."""
+
     def format(self, record):
         self.add_color(record)
         s = ExtrasFormatter.format(self, record)

--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -71,6 +71,7 @@ class ExtrasFormatter(logging.Formatter):
 
     def add_extras(self, record):
         if self.keywords is None or not hasattr(record, '_daiquiri_extra'):
+            record.extras = ''
             return
 
         # Format any unknown keyword arguments into the extras string.
@@ -95,10 +96,10 @@ class ExtrasFormatter(logging.Formatter):
         return s
 
 
-class ColorExtrasFormatter(ExtrasFormatter, ColorFormatter):
+class ColorExtrasFormatter(ColorFormatter, ExtrasFormatter):
     def format(self, record):
         self.add_color(record)
-        s = super(ColorExtrasFormatter, self).format(record)
+        s = ExtrasFormatter.format(self, record)
         self.remove_color(record)
         return s
 

--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -19,6 +19,11 @@ except ImportError:
 
 DEFAULT_FORMAT = (
     "%(asctime)s [%(process)d] %(color)s%(levelname)-8.8s "
+    "%(name)s: %(message)s%(color_stop)s"
+)
+
+DEFAULT_EXTRAS_FORMAT = (
+    "%(asctime)s [%(process)d] %(color)s%(levelname)-8.8s "
     "%(name)s%(extras)s: %(message)s%(color_stop)s"
 )
 
@@ -91,22 +96,18 @@ class ExtrasFormatter(logging.Formatter):
     """
 
     def __init__(self,
-                 fmt=None,
-                 datefmt=None,
-                 style='%',
                  keywords=None,
                  extras_template='[{0}: {1}]',
                  extras_separator=' ',
                  extras_prefix=' ',
-                 extras_suffix=''):
+                 extras_suffix='',
+                 *args, **kwargs):
         self.keywords = keywords
         self.extras_template = extras_template
         self.extras_separator = extras_separator
         self.extras_prefix = extras_prefix
         self.extras_suffix = extras_suffix
-        super(ExtrasFormatter, self).__init__(fmt=fmt,
-                                              datefmt=datefmt,
-                                              style=style)
+        super(ExtrasFormatter, self).__init__(*args, **kwargs)
 
     def add_extras(self, record):
         if self.keywords is None or not hasattr(record, '_daiquiri_extra'):
@@ -142,6 +143,6 @@ class ColorExtrasFormatter(ColorFormatter, ExtrasFormatter):
         return s
 
 
-TEXT_FORMATTER = ColorExtrasFormatter(fmt=DEFAULT_FORMAT)
+TEXT_FORMATTER = ColorExtrasFormatter(fmt=DEFAULT_EXTRAS_FORMAT)
 if jsonlogger:
     JSON_FORMATTER = jsonlogger.JsonFormatter()

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -40,6 +40,10 @@ class TestDaiquiri(testtools.TestCase):
         self.assertEqual({"message": "foobar"},
                          json.loads(stream.getvalue()))
 
+    def test_get_logger_set_level(self):
+        logger = daiquiri.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)
+
     def test_capture_warnings(self):
         stream = six.moves.StringIO()
         daiquiri.setup(outputs=(
@@ -48,7 +52,7 @@ class TestDaiquiri(testtools.TestCase):
         warnings.warn("omg!")
         line = stream.getvalue()
         self.assertIn("WARNING  py.warnings: ", line)
-        self.assertIn("daiquiri/tests/test_daiquiri.py:48: "
+        self.assertIn("daiquiri/tests/test_daiquiri.py:52: "
                       "UserWarning: omg!\n  warnings.warn(\"omg!\")\n",
                       line)
 

--- a/daiquiri/tests/test_formatter.py
+++ b/daiquiri/tests/test_formatter.py
@@ -4,7 +4,7 @@ import six
 import daiquiri
 
 
-class TestExtrasFormatter(testtools.TestCase):
+class TestColorExtrasFormatter(testtools.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.logger = daiquiri.getLogger('my_module')
@@ -12,7 +12,7 @@ class TestExtrasFormatter(testtools.TestCase):
         cls.stream = six.moves.StringIO()
         cls.handler = daiquiri.handlers.TTYDetectorStreamHandler(cls.stream)
         cls.logger.logger.addHandler(cls.handler)
-        super(TestExtrasFormatter, cls).setUpClass()
+        super(TestColorExtrasFormatter, cls).setUpClass()
 
     def setUp(self):
         # Couldn't get readline() to return anything no matter what I tried, so
@@ -21,11 +21,11 @@ class TestExtrasFormatter(testtools.TestCase):
         self.stream.close()
         self.stream = six.moves.StringIO()
         self.handler.stream = self.stream
-        super(TestExtrasFormatter, self).setUp()
+        super(TestColorExtrasFormatter, self).setUp()
 
     def test_no_keywords(self):
         format_string = '%(levelname)s %(name)s%(extras)s: %(message)s'
-        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string)
+        formatter = daiquiri.formatter.ColorExtrasFormatter(fmt=format_string)
         self.handler.setFormatter(formatter)
 
         self.logger.info('test message')
@@ -34,7 +34,7 @@ class TestExtrasFormatter(testtools.TestCase):
 
     def test_no_keywords_with_extras(self):
         format_string = '%(levelname)s %(name)s%(extras)s: %(message)s'
-        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string)
+        formatter = daiquiri.formatter.ColorExtrasFormatter(fmt=format_string)
         self.handler.setFormatter(formatter)
 
         # The formatter.keywords is None, so "extras" functionality
@@ -46,8 +46,8 @@ class TestExtrasFormatter(testtools.TestCase):
 
     def test_empty_keywords(self):
         format_string = '%(levelname)s %(name)s%(extras)s: %(message)s'
-        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string,
-                                                       keywords=[])
+        formatter = daiquiri.formatter.ColorExtrasFormatter(fmt=format_string,
+                                                            keywords=[])
         self.handler.setFormatter(formatter)
 
         self.logger.info('test message', test="a")
@@ -57,8 +57,8 @@ class TestExtrasFormatter(testtools.TestCase):
     def test_keywords_no_extras(self):
         format_string = ('%(levelname)s %(name)s'
                          ' %(test)s%(extras)s: %(message)s')
-        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string,
-                                                       keywords=["test"])
+        formatter = daiquiri.formatter.ColorExtrasFormatter(fmt=format_string,
+                                                            keywords=["test"])
         self.handler.setFormatter(formatter)
 
         self.logger.info('test message', test="a")
@@ -68,8 +68,8 @@ class TestExtrasFormatter(testtools.TestCase):
     def test_keywords_with_extras(self):
         format_string = ('%(levelname)s %(name)s'
                          ' %(test)s%(extras)s: %(message)s')
-        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string,
-                                                       keywords=["test"])
+        formatter = daiquiri.formatter.ColorExtrasFormatter(fmt=format_string,
+                                                            keywords=["test"])
         self.handler.setFormatter(formatter)
 
         self.logger.info('test message', test="a", test2="b")

--- a/daiquiri/tests/test_formatter.py
+++ b/daiquiri/tests/test_formatter.py
@@ -1,6 +1,19 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 import logging
-import testtools
+
 import six
+import testtools
+
 import daiquiri
 
 

--- a/daiquiri/tests/test_formatter.py
+++ b/daiquiri/tests/test_formatter.py
@@ -1,0 +1,77 @@
+import logging
+import testtools
+import six
+import daiquiri
+
+
+class TestExtrasFormatter(testtools.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.logger = daiquiri.getLogger('my_module')
+        cls.logger.setLevel(logging.INFO)
+        cls.stream = six.moves.StringIO()
+        cls.handler = daiquiri.handlers.TTYDetectorStreamHandler(cls.stream)
+        cls.logger.logger.addHandler(cls.handler)
+        super(TestExtrasFormatter, cls).setUpClass()
+
+    def setUp(self):
+        # Couldn't get readline() to return anything no matter what I tried, so
+        # getvalue() is the only way to see what's in the stream. However this
+        # requires the stream to be reset every time.
+        self.stream.close()
+        self.stream = six.moves.StringIO()
+        self.handler.stream = self.stream
+        super(TestExtrasFormatter, self).setUp()
+
+    def test_no_keywords(self):
+        format_string = '%(levelname)s %(name)s%(extras)s: %(message)s'
+        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string)
+        self.handler.setFormatter(formatter)
+
+        self.logger.info('test message')
+        self.assertEqual(self.stream.getvalue(),
+                         'INFO my_module: test message\n')
+
+    def test_no_keywords_with_extras(self):
+        format_string = '%(levelname)s %(name)s%(extras)s: %(message)s'
+        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string)
+        self.handler.setFormatter(formatter)
+
+        # The formatter.keywords is None, so "extras" functionality
+        # won't be turned on even though addtional keyword arguments
+        # are being passed into the log method.
+        self.logger.info('test message', test="a")
+        self.assertEqual(self.stream.getvalue(),
+                         'INFO my_module: test message\n')
+
+    def test_empty_keywords(self):
+        format_string = '%(levelname)s %(name)s%(extras)s: %(message)s'
+        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string,
+                                                       keywords=[])
+        self.handler.setFormatter(formatter)
+
+        self.logger.info('test message', test="a")
+        self.assertEqual(self.stream.getvalue(),
+                         'INFO my_module [test: a]: test message\n')
+
+    def test_keywords_no_extras(self):
+        format_string = ('%(levelname)s %(name)s'
+                         ' %(test)s%(extras)s: %(message)s')
+        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string,
+                                                       keywords=["test"])
+        self.handler.setFormatter(formatter)
+
+        self.logger.info('test message', test="a")
+        self.assertEqual(self.stream.getvalue(),
+                         'INFO my_module a: test message\n')
+
+    def test_keywords_with_extras(self):
+        format_string = ('%(levelname)s %(name)s'
+                         ' %(test)s%(extras)s: %(message)s')
+        formatter = daiquiri.formatter.ExtrasFormatter(fmt=format_string,
+                                                       keywords=["test"])
+        self.handler.setFormatter(formatter)
+
+        self.logger.info('test message', test="a", test2="b")
+        self.assertEqual(self.stream.getvalue(),
+                         'INFO my_module a [test2: b]: test message\n')

--- a/daiquiri/tests/test_output.py
+++ b/daiquiri/tests/test_output.py
@@ -9,8 +9,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-from datetime import timedelta
 import syslog
+from datetime import timedelta
 
 import testtools
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,5 +1,6 @@
-import daiquiri
 import logging
+
+import daiquiri
 
 daiquiri.setup(level=logging.INFO)
 

--- a/examples/extra.py
+++ b/examples/extra.py
@@ -1,6 +1,7 @@
+import logging
+
 import daiquiri
 import daiquiri.formatter
-import logging
 
 daiquiri.setup(level=logging.INFO, outputs=(
     daiquiri.output.Stream(formatter=daiquiri.formatter.ColorFormatter(

--- a/examples/files.py
+++ b/examples/files.py
@@ -1,6 +1,7 @@
-import daiquiri
 import datetime
 import logging
+
+import daiquiri
 
 daiquiri.setup(
     level=logging.DEBUG,

--- a/examples/formatter.py
+++ b/examples/formatter.py
@@ -1,6 +1,7 @@
+import logging
+
 import daiquiri
 import daiquiri.formatter
-import logging
 
 daiquiri.setup(level=logging.INFO, outputs=(
     daiquiri.output.Stream(formatter=daiquiri.formatter.ColorFormatter(

--- a/examples/output.py
+++ b/examples/output.py
@@ -1,6 +1,7 @@
-import daiquiri
 import logging
 import sys
+
+import daiquiri
 
 # Log both to stdout and as JSON in a file called /dev/null. (Requires
 # `python-json-logger`)

--- a/examples/stringnames.py
+++ b/examples/stringnames.py
@@ -1,5 +1,6 @@
-import daiquiri
 import logging
+
+import daiquiri
 
 daiquiri.setup(level=logging.INFO, outputs=('stdout', 'stderr'))
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = flake8
 # E123, E125 skipped as they are invalid PEP-8.
 show-source = True
 ignore = E123,E125,H405,H102
-exclude=.git,.tox,dist,build
+exclude=.git,.tox,dist,build,.eggs
 
 [testenv:docs]
 deps = sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,7 @@ deps =
 commands = flake8
 
 [flake8]
-# E123, E125 skipped as they are invalid PEP-8.
 show-source = True
-ignore = E123,E125,H405,H102
 exclude=.git,.tox,dist,build,.eggs
 application-import-names=daiquiri
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,8 @@ commands =
   sh -c "rm errors.log everything.log"
 
 [testenv:pep8]
-deps =
-  pep8
-  hacking>=0.13,<0.14
-commands =
-  flake8
+deps = flake8
+commands = flake8
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,9 @@ commands =
   sh -c "rm errors.log everything.log"
 
 [testenv:pep8]
-deps = flake8
+deps =
+    flake8
+    flake8-import-order
 commands = flake8
 
 [flake8]
@@ -18,6 +20,7 @@ commands = flake8
 show-source = True
 ignore = E123,E125,H405,H102
 exclude=.git,.tox,dist,build,.eggs
+application-import-names=daiquiri
 
 [testenv:docs]
 deps = sphinx


### PR DESCRIPTION
I have created a new adapter which works well with the rest of the daiquiri system. This adapter allows a single logger to be passed arbitrary parameters which will then be formatted and included in the log message in place of the `%(context)s` match. I plan on using this in my own project, but it seems like it could be generally useful and fits within the scope of the daiquiri project.

Here is an example of how it is used:
```python
>>> name = "my_module"
>>> logger = daiquiri.getLogger(name,
                                adapter_class=daiquiri.ArbitraryContextAdapter,
                                level=logging.INFO)
>>> handler = logging.StreamHandler(sys.stdout)
>>> format_string = "%(asctime)s %(name)s %(levelname)s%(context)s: %(message)"
>>> handler.setFormatter(daiquiri.formatter.ColorFormatter(fmt=format_string))
>>> logger.logger.addHandler(handler)
>>> logger.info("A message.", test1="a", test2="b")
2017-08-18 17:10:20,212 my_module INFO [test1: a] [test2: b]: A message.
>>> logger.info("Another message.", test1="a", test2="b", test3="c")
2017-08-18 17:10:20,212 my_module INFO [test1: a] [test2: b] [test3: c]: A message.
```

Currently there are a couple of small quirks with this PR as is. They are acceptable for my project, but I would be happy to clean them up if this is functionality is something you would in fact consider for this library. These quirks are:
  * The context string is preceded by an extra space character.
  * The parameter template is not configurable. I believe I could overwrite the constructor for the ArbitraryContextAdapter to accept a parameter template instead of always using `[{0}: {1}]`.