### PR TITLE
Fix JSON encoding with extra keys

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -46,7 +46,7 @@ class KeywordArgumentAdapter(logging.LoggerAdapter):
             if name == 'exc_info':
                 continue
             extra[name] = kwargs.pop(name)
-        extra['_daiquiri_extra'] = extra
+        extra['_daiquiri_extra_keys'] = set(extra.keys())
         kwargs['extra'] = extra
         return msg, kwargs
 

--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -110,14 +110,14 @@ class ExtrasFormatter(logging.Formatter):
         super(ExtrasFormatter, self).__init__(*args, **kwargs)
 
     def add_extras(self, record):
-        if self.keywords is None or not hasattr(record, '_daiquiri_extra'):
+        if self.keywords is None or not hasattr(record, '_daiquiri_extra_keys'):
             record.extras = ''
             return
 
         extras = self.extras_separator.join(
-            self.extras_template.format(k, v)
-            for k, v in record._daiquiri_extra.items()
-            if k != '_daiquiri_extra' and k not in self.keywords
+            self.extras_template.format(k, getattr(record, k))
+            for k in record._daiquiri_extra_keys
+            if k != '_daiquiri_extra_keys' and k not in self.keywords
         )
         if extras != '':
             extras = self.extras_prefix + extras + self.extras_suffix

--- a/daiquiri/handlers.py
+++ b/daiquiri/handlers.py
@@ -88,10 +88,10 @@ class JournalHandler(logging.Handler):
         if record.exc_info:
             extras['EXCEPTION_INFO'] = record.exc_info
 
-        if hasattr(record, "_daiquiri_extra"):
-            for k, v in record._daiquiri_extra.items():
-                if k != "_daiquiri_extra":
-                    extras[k.upper()] = v
+        if hasattr(record, "_daiquiri_extra_keys"):
+            for k, v in record._daiquiri_extra_keys:
+                if k != "_daiquiri_extra_keys":
+                    extras[k.upper()] = getattr(record, k)
 
         journal.send(message, **extras)
 

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -40,6 +40,16 @@ class TestDaiquiri(unittest.TestCase):
         self.assertEqual({"message": "foobar"},
                          json.loads(stream.getvalue()))
 
+    def test_setup_json_formatter_with_extras(self):
+        stream = six.moves.StringIO()
+        daiquiri.setup(outputs=(
+            daiquiri.output.Stream(
+                stream, formatter=daiquiri.formatter.JSON_FORMATTER),
+        ))
+        daiquiri.getLogger(__name__).warning("foobar", foo="bar")
+        self.assertEqual({"message": "foobar", "foo": "bar"},
+                         json.loads(stream.getvalue()))
+
     def test_get_logger_set_level(self):
         logger = daiquiri.getLogger(__name__)
         logger.setLevel(logging.DEBUG)
@@ -52,7 +62,7 @@ class TestDaiquiri(unittest.TestCase):
         warnings.warn("omg!")
         line = stream.getvalue()
         self.assertIn("WARNING  py.warnings: ", line)
-        self.assertIn("daiquiri/tests/test_daiquiri.py:52: "
+        self.assertIn("daiquiri/tests/test_daiquiri.py:62: "
                       "UserWarning: omg!\n  warnings.warn(\"omg!\")\n",
                       line)
 


### PR DESCRIPTION
_daiquiri_extra refers to the extra dict, which builds a circular dependency
and makes it impossible to encode the record in JSON easily.
This changes the code to only stores a list of keys rather than the dict.