### PR TITLE
ttydetector: don't fail during interpretor shutdown

### DIFF
--- a/daiquiri/handlers.py
+++ b/daiquiri/handlers.py
@@ -101,7 +101,11 @@ class TTYDetectorStreamHandler(logging.StreamHandler):
 
     def format(self, record):
         if hasattr(self.stream, "isatty"):
-            record._stream_is_a_tty = self.stream.isatty()
+            try:
+                record._stream_is_a_tty = self.stream.isatty()
+            except ValueError:
+                # Stream has been closed, usually during interpretor shutdown
+                record._stream_is_a_tty = False
         else:
             record._stream_is_a_tty = False
         s = super(TTYDetectorStreamHandler, self).format(record)


### PR DESCRIPTION
When logging occurs during an atexit callback, we got the following
exception:

Traceback (most recent call last):
  File "/usr/lib64/python3.8/logging/__init__.py", line 1081, in emit
    msg = self.format(record)
  File "../.tox/py38/lib/python3.8/site-packages/daiquiri/handlers.py", line 104, in format
    record._stream_is_a_tty = self.stream.isatty()
ValueError: I/O operation on closed file

This change fixes it.
