### PR TITLE
Parameterize setting `sys.excepthook`

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -68,7 +68,7 @@ def getLogger(name=None, **kwargs):
 
 
 def setup(level=logging.WARNING, outputs=[output.STDERR], program_name=None,
-          capture_warnings=True):
+          capture_warnings=True, set_excepthook=True):
     """Setup Python logging.
 
     This will setup basic handlers for Python logging.
@@ -94,13 +94,14 @@ def setup(level=logging.WARNING, outputs=[output.STDERR], program_name=None,
 
     root_logger.setLevel(level)
 
-    program_logger = logging.getLogger(program_name)
+    if set_excepthook:
+        program_logger = logging.getLogger(program_name)
 
-    def logging_excepthook(exc_type, value, tb):
-        program_logger.critical(
-            "".join(traceback.format_exception(exc_type, value, tb)))
+        def logging_excepthook(exc_type, value, tb):
+            program_logger.critical(
+                "".join(traceback.format_exception(exc_type, value, tb)))
 
-    sys.excepthook = logging_excepthook
+        sys.excepthook = logging_excepthook
 
     if capture_warnings:
         logging.captureWarnings(True)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -124,6 +124,18 @@ interval.
 
 .. literalinclude:: ../../examples/files.py
 
+
+Excepthook Integration
+----------------------
+
+The `daiquiri.setup` method accepts an optional `set_excepthook` keyword argument
+(defaults to `True`) which controls whether or not Daiquiri will override the
+global `sys.excepthook`. Disabling this can be useful when using Daiquiri alongside
+another library which requires setting the excepthook, e.g. an error reporting
+library.
+
+.. literalinclude:: ../../examples/excepthook.py
+
 API
 ===
 .. automodule:: daiquiri

--- a/examples/excepthook.py
+++ b/examples/excepthook.py
@@ -3,4 +3,5 @@ import daiquiri
 daiquiri.setup(set_excepthook=False)
 logger = daiquiri.getLogger(__name__)
 
-raise Exception("Something went wrong") # This exception will not pass through Daiquiri
+# This exception will not pass through Daiquiri:
+raise Exception("Something went wrong")

--- a/examples/excepthook.py
+++ b/examples/excepthook.py
@@ -1,0 +1,6 @@
+import daiquiri
+
+daiquiri.setup(set_excepthook=False)
+logger = daiquiri.getLogger(__name__)
+
+raise Exception("Something went wrong") # This exception will not pass through Daiquiri


### PR DESCRIPTION
This adds a new flag option, `set_excepthook` to `daiquiri.setup` which can be used to disable overwriting the global exception hook. This is useful in cases where one would want to use daiquiri alongside an error reporting library, _.e.g._ Sentry, where both libraries will be fighting over the excepthook.

Being able to disable daiquiri overwriting the excepthook means that an explicit precedence can be set between multiple libraries which want to make use of it.