### PR TITLE
handle "stack_info" argument correctly

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -42,7 +42,7 @@ class KeywordArgumentAdapter(logging.LoggerAdapter):
         # Move any unknown keyword arguments into the extra
         # dictionary.
         for name in list(kwargs.keys()):
-            if name == "exc_info":
+            if name in ("exc_info", "stack_info"):
                 continue
             extra[name] = kwargs.pop(name)
         extra["_daiquiri_extra_keys"] = set(extra.keys())

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -93,9 +93,11 @@ class TestDaiquiri(unittest.TestCase):
 
         if daiquiri.handlers.journal is not None:
             daiquiri.setup(outputs=("journal",))
-    
+
     def test_special_kwargs(self):
-        daiquiri.getLogger(__name__).info("foobar", foo="bar", exc_info=True, stack_info=True)
+        daiquiri.getLogger(__name__).info(
+            "foobar", foo="bar", exc_info=True, stack_info=True
+        )
 
 
 def test_extra_with_two_loggers():

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -93,6 +93,9 @@ class TestDaiquiri(unittest.TestCase):
 
         if daiquiri.handlers.journal is not None:
             daiquiri.setup(outputs=("journal",))
+    
+    def test_special_kwargs(self):
+        daiquiri.getLogger(__name__).info("foobar", foo="bar", exc_info=True, stack_info=True)
 
 
 def test_extra_with_two_loggers():


### PR DESCRIPTION
first of all awesome lib, thank you! :)

currently `stack_info` argument is being added to extra instead of being passed on to the logger, which results in an exception. Fixing this to adhere to the builtin logger API.

```
In [3]: l.info('test', a=1, stack_info=True)                                                                                                                                                                                                                                                                                   
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-3-665856060777> in <module>
----> 1 l.info('test', a=1, stack_info=True)

/usr/local/lib/python3.9/logging/__init__.py in info(self, msg, *args, **kwargs)
   1800         Delegate an info call to the underlying logger.
   1801         """
-> 1802         self.log(INFO, msg, *args, **kwargs)
   1803 
   1804     def warning(self, msg, *args, **kwargs):

/usr/local/lib/python3.9/logging/__init__.py in log(self, level, msg, *args, **kwargs)
   1838         if self.isEnabledFor(level):
   1839             msg, kwargs = self.process(msg, kwargs)
-> 1840             self.logger.log(level, msg, *args, **kwargs)
   1841 
   1842     def isEnabledFor(self, level):

/usr/local/lib/python3.9/logging/__init__.py in log(self, level, msg, *args, **kwargs)
   1506                 return
   1507         if self.isEnabledFor(level):
-> 1508             self._log(level, msg, args, **kwargs)
   1509 
   1510     def findCaller(self, stack_info=False, stacklevel=1):

/usr/local/lib/python3.9/logging/__init__.py in _log(self, level, msg, args, exc_info, extra, stack_info, stacklevel)
   1581             elif not isinstance(exc_info, tuple):
   1582                 exc_info = sys.exc_info()
-> 1583         record = self.makeRecord(self.name, level, fn, lno, msg, args,
   1584                                  exc_info, func, extra, sinfo)
   1585         self.handle(record)

/usr/local/lib/python3.9/logging/__init__.py in makeRecord(self, name, level, fn, lno, msg, args, exc_info, func, extra, sinfo)
   1555             for key in extra:
   1556                 if (key in ["message", "asctime"]) or (key in rv.__dict__):
-> 1557                     raise KeyError("Attempt to overwrite %r in LogRecord" % key)
   1558                 rv.__dict__[key] = extra[key]
   1559         return rv

KeyError: "Attempt to overwrite 'stack_info' in LogRecord"
```